### PR TITLE
Generalize the description so it doesn't say "Crescent Commute"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hubot-commute
 
-A hubot script for the Crescent Commute
+A hubot script for calculating the time it would take to commute now
 
 See [`src/commute.coffee`](src/commute.coffee) for full documentation.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-commute",
-  "description": "A hubot script for the Crescent Commute",
+  "description": "A hubot script for calculating the time it would take to commute now",
   "version": "0.0.0",
   "author": "Robert McLaughlin <rmclaughlin@constantcontact.com>",
   "license": "MIT",

--- a/src/commute.js
+++ b/src/commute.js
@@ -1,5 +1,5 @@
 // Description
-//   A hubot script for the Crescent Commute
+//   A hubot script for calculating the time it would take to commute now
 //
 // Configuration:
 //   HUBOT_COMMUTE_MAPS_KEY: your google maps API key


### PR DESCRIPTION
Changes this:
> A hubot script for the Crescent Commute

To this:
> A hubot script for the calculating the time it would take to commute now

Originally I thought this plugin was hard coded to only support our address (it doesn't), so I think this will make it more clear. If you merge this, don't forget to update the GitHub repo's description.